### PR TITLE
fix module declaration for future release on github

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module gtab
+module github.com/mjkahlke/gtab
 
 go 1.18


### PR DESCRIPTION
changed module declaration with "go mod init github.com/mjkahlke/gtab"