### PR TITLE
use Alpine to reduce footprint; changes for Docker Desktop; update go…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:latest
+FROM golang:1.19-alpine
+# Install gcc tools, required for unit tests
+RUN apk add build-base
 
 MAINTAINER mjkgit@gmail.com
 

--- a/cmd/cli/go.mod
+++ b/cmd/cli/go.mod
@@ -1,6 +1,6 @@
 module gtab/cli
 
-go 1.18
+go 1.20.5
 
 replace gtab/impl => ..\..\impl
 

--- a/cmd/rest/go.mod
+++ b/cmd/rest/go.mod
@@ -1,6 +1,6 @@
 module gtab/rest
 
-go 1.18
+go 1.20.5
 
 replace gtab/impl => ..\..\impl
 

--- a/impl/go.mod
+++ b/impl/go.mod
@@ -1,3 +1,3 @@
 module gtab/impl
 
-go 1.18
+go 1.20.5


### PR DESCRIPTION
… version to 1.20.5

I made some changes:

- alpine to reduce image footpring
- need to add gcc so unit tests work as alpine doesn't include it
- updated go version from 1.18 to 1.20.5
